### PR TITLE
feat: add github paris developer listing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxx

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import TheFooter from './components/TheFooter.vue';
+import { NuxtRouteAnnouncer, NuxtPage } from '#components';
 
 </script>
 
 <template>
   <div>
     <NuxtRouteAnnouncer />
-    <NuxtWelcome />
+    <NuxtPage />
     <TheFooter />
   </div>
 </template>

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,0 +1,11 @@
+schema:
+  - https://api.github.com/graphql:
+      headers:
+        Authorization: Bearer ${GITHUB_TOKEN}
+documents: "queries/**/*.graphql"
+generates:
+  types/github.ts:
+    plugins:
+      - typescript
+      - typescript-operations
+      - typescript-graphql-request

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,6 +3,7 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
   modules: ['@nuxt/eslint', '@nuxt/ui', '@nuxt/image'],
+  css: ['~/assets/css/tailwind.css'],
   imports: {
     // disable auto-import
     autoImport: false,

--- a/package.json
+++ b/package.json
@@ -7,13 +7,16 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "codegen": "graphql-codegen"
   },
   "dependencies": {
     "@nuxt/eslint": "1.7.1",
     "@nuxt/image": "1.11.0",
     "@nuxt/ui": "3.3.0",
     "eslint": "^9.32.0",
+    "graphql": "^16.9.0",
+    "graphql-request": "^7.1.0",
     "nuxt": "^4.0.1",
     "typescript": "^5.9.2",
     "vue": "^3.5.18",
@@ -21,6 +24,13 @@
   },
   "packageManager": "pnpm@10.14.0+sha256.297534e65d5842450539c1e8022c8831ab5e1fe2eb74664787a815519542d620",
   "devDependencies": {
+    "@graphql-codegen/cli": "^5.0.2",
+    "@graphql-codegen/typescript": "^5.0.2",
+    "@graphql-codegen/typescript-graphql-request": "^5.0.2",
+    "@graphql-codegen/typescript-operations": "^5.0.2",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.4",
     "unplugin-vue-router": "^0.15.0",
     "vue-tsc": "^3.0.5"
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,26 @@
+<!-- eslint-disable vue/multi-word-component-names -->
+<script setup lang="ts">
+import { useFetch } from '#imports'
+
+const { data, pending, error } = await useFetch('/api/github/top-paris')
+</script>
+
+<template>
+  <div class="p-6">
+    <h1 class="text-2xl font-bold mb-4">Top 50 Developers in Paris</h1>
+    <div v-if="pending">Loading...</div>
+    <div v-else-if="error" class="text-red-500">Error: {{ error.message }}</div>
+    <ul v-else class="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <li
+        v-for="dev in data"
+        :key="dev.login"
+        class="p-4 border rounded-lg flex flex-col items-center"
+      >
+        <img :src="dev.avatarUrl" alt="" class="w-16 h-16 rounded-full mb-2" />
+        <p class="font-semibold">{{ dev.name || dev.login }}</p>
+        <p class="text-gray-500">@{{ dev.login }}</p>
+        <p class="text-sm text-gray-600">{{ dev.followers.totalCount }} followers</p>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/queries/TopParisDevs.graphql
+++ b/queries/TopParisDevs.graphql
@@ -1,0 +1,16 @@
+query TopParisDevs {
+  search(query: "location:paris type:user", type: USER, first: 50) {
+    edges {
+      node {
+        ... on User {
+          login
+          name
+          avatarUrl
+          followers {
+            totalCount
+          }
+        }
+      }
+    }
+  }
+}

--- a/server/api/github/top-paris.get.ts
+++ b/server/api/github/top-paris.get.ts
@@ -1,0 +1,7 @@
+import { defineEventHandler } from 'h3'
+import { githubSdk } from '~/server/utils/github'
+
+export default defineEventHandler(async () => {
+  const data = await githubSdk.TopParisDevs()
+  return data.search.edges?.map((edge) => edge?.node) || []
+})

--- a/server/utils/github.ts
+++ b/server/utils/github.ts
@@ -1,0 +1,8 @@
+import { GraphQLClient } from 'graphql-request'
+import { getSdk } from '~/types/github'
+
+const client = new GraphQLClient('https://api.github.com/graphql', {
+  headers: { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+})
+
+export const githubSdk = getSdk(client)

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'tailwindcss'
+
+export default {
+  content: [
+    './app/**/*.{vue,js,ts}',
+    './components/**/*.{vue,js,ts}',
+    './pages/**/*.{vue,js,ts}',
+    './server/**/*.{js,ts}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config

--- a/types/github.ts
+++ b/types/github.ts
@@ -1,0 +1,50 @@
+import { gql } from 'graphql-request'
+import type { GraphQLClient } from 'graphql-request'
+
+export type TopParisDevsQuery = {
+  search: {
+    edges?: Array<{
+      node?: {
+        __typename?: 'User'
+        login: string
+        name?: string | null
+        avatarUrl: string
+        followers: { totalCount: number }
+      } | null
+    } | null> | null
+  }
+}
+
+export type TopParisDevsQueryVariables = Record<string, never>
+
+export const TopParisDevsDocument = gql`
+  query TopParisDevs {
+    search(query: "location:paris type:user", type: USER, first: 50) {
+      edges {
+        node {
+          ... on User {
+            login
+            name
+            avatarUrl
+            followers {
+              totalCount
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+export function getSdk(client: GraphQLClient) {
+  return {
+    TopParisDevs(
+      variables?: TopParisDevsQueryVariables,
+      requestHeaders?: HeadersInit,
+    ): Promise<TopParisDevsQuery> {
+      return client.request<TopParisDevsQuery>(TopParisDevsDocument, variables, requestHeaders)
+    },
+  }
+}
+
+export type Sdk = ReturnType<typeof getSdk>


### PR DESCRIPTION
## Summary
- add GitHub GraphQL integration and Paris developer query
- expose `/api/github/top-paris` endpoint and basic UI
- set up Tailwind and related build tooling

## Testing
- `pnpm codegen` *(fails: graphql-codegen not found)*
- `pnpm exec eslint pages/index.vue types/github.ts` *(fails: 1 warning)*
- `pnpm build` *(fails: Could not initialize provider googleicons)*

------
https://chatgpt.com/codex/tasks/task_e_689215c40968832aa55fc0a853f2abc0