### PR TITLE
feat: add user agent for GitHub GraphQL

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -1,0 +1,7 @@
+schema:
+  https://api.github.com/graphql:
+    headers:
+      Authorization: Bearer ${GITHUB_TOKEN}
+      User-Agent: ${GITHUB_USER_AGENT:-devs-moneyball}
+documents: []
+generates: {}

--- a/server/utils/github.ts
+++ b/server/utils/github.ts
@@ -1,0 +1,10 @@
+import { GraphQLClient } from 'graphql-request'
+
+const USER_AGENT = process.env.GITHUB_USER_AGENT ?? 'devs-moneyball'
+
+export const githubClient = new GraphQLClient('https://api.github.com/graphql', {
+  headers: {
+    Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+    'User-Agent': USER_AGENT,
+  },
+})


### PR DESCRIPTION
## Summary
- include a User-Agent header for GitHub GraphQL in codegen config
- send the same User-Agent header from the server GitHub client

## Testing
- `pnpm codegen` *(fails: Command "codegen" not found)*

------
https://chatgpt.com/codex/tasks/task_e_689219b6bda4832a829fb959911d8357